### PR TITLE
feat: add node_taints support to nodepool module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -85,6 +85,15 @@ resource "google_container_node_pool" "nodepool" {
       }
     }
 
+    dynamic "taint" {
+      for_each = var.node_taints
+      content {
+        key    = taint.value.key
+        value  = taint.value.value
+        effect = taint.value.effect
+      }
+    }
+
     dynamic "sandbox_config" {
       for_each = (
         var.node_sandbox_config != null

--- a/variables.tf
+++ b/variables.tf
@@ -167,6 +167,16 @@ variable "node_shielded_instance_config" {
   default = null
 }
 
+variable "node_taints" {
+  description = "Kubernetes taints applied to nodes."
+  type = list(object({
+    key    = string
+    value  = string
+    effect = string
+  }))
+  default = []
+}
+
 variable "node_tags" {
   description = "Network tags applied to nodes."
   type        = list(string)


### PR DESCRIPTION
adds a dynamic taint block inside node_config to apply Kubernetes taints to node pool nodes.